### PR TITLE
Export resultiers alongside Testable

### DIFF
--- a/src/Test/LeanCheck/Core.hs
+++ b/src/Test/LeanCheck/Core.hs
@@ -33,7 +33,7 @@ module Test.LeanCheck.Core
   , counterExamples
   , witness
   , witnesses
-  , Testable
+  , Testable(..)
 
   , results
 


### PR DESCRIPTION
Exporting `resultiers` along with `Testable` enables clients to define their own `Testable` instances. The immediate use case is to enable suspending equalities s.t. `resultiers` can provide messages as to what the expected and actual values of some tested property were:

```haskell
data ShouldBe where
  ShouldBe :: (Eq a, Show a) => a -> a -> ShouldBe

instance Testable ShouldBe where
  resultiers (ShouldBe actual expected) = fmap prependExpectation <$> resultiers (actual == expected)
    where prependExpectation (strs, False) = (("expected: " ++ show expected ++ "\n but got: " ++ show actual) : strs, False)
          prependExpectation other = other

prop_subtractionAssociativity = \ a b c -> (a - (b - c)) `ShouldBe` ((a - b) - c :: Integer)
```

This property does not hold, but now instead of only seeing the counterexamples, we also see the comparison:

```
0
0
1
expected: -1
 but got: 1
```