### PR TITLE
CI: test with GHC 9.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
     strategy:
       matrix:
         ghc:
+          - '9.2'
           - '9.0'
           - '8.10'
           - '8.8'


### PR DESCRIPTION
Hi, I'm not sure this is the kind of update you're looking for, but I thought it'd be nice anyway. I'm looking into this because I'm getting the following error with LeanCheck on GHC 9.2.4:

```
tests/Main.hs:1:1: error:
    Exception when trying to run compile-time code:
      error (typeArity): symbol GHC.Prim.ByteArray# is not a newtype, data or type synonym
CallStack (from HasCallStack):
  error, called at src/Test/LeanCheck/Derive.hs:273:10 in leancheck-0.9.10-3bd55c2110c9808fba2f61d85cd6246868c6e54113deb01678d7aec19341f7e9:Test.LeanCheck.Derive
    Code: deriveListableCascading ''AST.Expr
```